### PR TITLE
chore: upgrade React to 19.2.3 and update types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "image-web-editor",
-  "version": "0.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "image-web-editor",
-      "version": "0.0.0",
+      "version": "1.2.0",
       "dependencies": {
         "clsx": "^2.1.1",
         "effector": "^23.4.4",
         "effector-react": "^23.3.0",
         "lucide-react": "^0.562.0",
         "patronum": "^2.3.0",
-        "react": "^19.2.0",
-        "react-dom": "^19.2.0",
+        "react": "^19.2.3",
+        "react-dom": "^19.2.3",
         "tailwind-merge": "^3.4.0"
       },
       "devDependencies": {
@@ -25,7 +25,7 @@
         "@testing-library/react": "^16.3.1",
         "@trivago/prettier-plugin-sort-imports": "^6.0.2",
         "@types/node": "^24.10.1",
-        "@types/react": "^19.2.5",
+        "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.1",
         "@vitest/ui": "^4.0.16",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "effector-react": "^23.3.0",
     "lucide-react": "^0.562.0",
     "patronum": "^2.3.0",
-    "react": "^19.2.0",
-    "react-dom": "^19.2.0",
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3",
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {
@@ -38,7 +38,7 @@
     "@testing-library/react": "^16.3.1",
     "@trivago/prettier-plugin-sort-imports": "^6.0.2",
     "@types/node": "^24.10.1",
-    "@types/react": "^19.2.5",
+    "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",
     "@vitest/ui": "^4.0.16",


### PR DESCRIPTION
- Update react and react-dom to 19.2.3
- Update @types/react to 19.2.7
- Update package-lock.json and ensure all tests pass