### PR TITLE
feat: сохранение кадра с выбором пути через Save As

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "image-web-editor",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "image-web-editor",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "dependencies": {
         "clsx": "^2.1.1",
         "effector": "^23.4.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "image-web-editor",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/entities/image/__tests__/model.test.ts
+++ b/src/entities/image/__tests__/model.test.ts
@@ -150,4 +150,119 @@ describe('CanvasEditor', () => {
       expect(canvas.height).toBe(300);
     });
   });
+
+  describe('Export (toDataURL)', () => {
+    beforeEach(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (editor as any).img = {
+        naturalWidth: 2000,
+        naturalHeight: 1500,
+      };
+      editor.setDimensions(500, 300);
+    });
+
+    it('should export viewport frame, not original image dimensions', () => {
+      const canvas = editor.getCanvas();
+      const tempCanvas = document.createElement('canvas');
+      const createElementSpy = vi.spyOn(document, 'createElement');
+      createElementSpy.mockReturnValueOnce(tempCanvas);
+
+      const getContextSpy = vi.spyOn(tempCanvas, 'getContext');
+      const mockCtx = {
+        save: vi.fn(),
+        restore: vi.fn(),
+        clearRect: vi.fn(),
+        fillRect: vi.fn(),
+        drawImage: vi.fn(),
+        filter: '',
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      getContextSpy.mockReturnValue(mockCtx as any);
+
+      editor.toDataURL();
+
+      // Проверяем, что временный canvas создан с размерами кадра, а не оригинала
+      expect(tempCanvas.width).toBe(canvas.width);
+      expect(tempCanvas.height).toBe(canvas.height);
+    });
+
+    it('should export frame without grid even if grid is visible', () => {
+      // Устанавливаем сетку видимой через приватное свойство, чтобы не вызывать render
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (editor as any).isGridVisible = true;
+
+      // Создаем мок для временного canvas в toDataURL
+      const tempCanvas = document.createElement('canvas');
+      tempCanvas.width = 500;
+      tempCanvas.height = 300;
+      const mockTempCtx = {
+        save: vi.fn(),
+        restore: vi.fn(),
+        clearRect: vi.fn(),
+        fillRect: vi.fn(),
+        drawImage: vi.fn(),
+        filter: '',
+        beginPath: vi.fn(),
+        moveTo: vi.fn(),
+        lineTo: vi.fn(),
+        stroke: vi.fn(),
+      };
+
+      vi.spyOn(document, 'createElement').mockReturnValue(tempCanvas);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      vi.spyOn(tempCanvas, 'getContext').mockReturnValue(mockTempCtx as any);
+      vi.spyOn(tempCanvas, 'toDataURL').mockReturnValue(
+        'data:image/jpeg;base64,...',
+      );
+
+      editor.toDataURL();
+
+      // Проверяем, что drawImage был вызван (изображение отрисовано)
+      expect(mockTempCtx.drawImage).toHaveBeenCalled();
+      // Проверяем, что сетка НЕ была нарисована (нет вызовов beginPath для сетки)
+      expect(mockTempCtx.beginPath).not.toHaveBeenCalled();
+    });
+
+    it('should account for zoom and offset in export', () => {
+      editor.setZoom(2);
+      editor.setOffset({ x: 50, y: 30 });
+      const tempCanvas = document.createElement('canvas');
+      tempCanvas.width = 500;
+      tempCanvas.height = 300;
+      const getContextSpy = vi.spyOn(tempCanvas, 'getContext');
+      const mockCtx = {
+        save: vi.fn(),
+        restore: vi.fn(),
+        clearRect: vi.fn(),
+        fillRect: vi.fn(),
+        drawImage: vi.fn(),
+        filter: '',
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      getContextSpy.mockReturnValue(mockCtx as any);
+      vi.spyOn(document, 'createElement').mockReturnValue(tempCanvas);
+      vi.spyOn(tempCanvas, 'toDataURL').mockReturnValue(
+        'data:image/jpeg;base64,...',
+      );
+
+      editor.toDataURL();
+
+      // Проверяем, что drawImage вызван с учетом зума и офсета
+      expect(mockCtx.drawImage).toHaveBeenCalled();
+      const drawImageCall = mockCtx.drawImage.mock.calls[0];
+      // x = (width - drawWidth) / 2 + offset.x = (500 - 1000) / 2 + 50 = -200
+      // y = (height - drawHeight) / 2 + offset.y = (300 - 600) / 2 + 30 = -120
+      expect(drawImageCall[1]).toBe(-200); // x координата
+      expect(drawImageCall[2]).toBe(-120); // y координата
+      expect(drawImageCall[3]).toBe(1000); // drawWidth = 500 * 2
+      expect(drawImageCall[4]).toBe(600); // drawHeight = 300 * 2
+    });
+
+    it('should return empty string if image is not loaded', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (editor as any).img = null;
+      const result = editor.toDataURL();
+      expect(result).toBe('');
+    });
+  });
 });

--- a/src/entities/image/model.ts
+++ b/src/entities/image/model.ts
@@ -12,12 +12,7 @@ import {
   INITIAL_OFFSET,
   INITIAL_ZOOM,
 } from './constants';
-import {
-  applyFiltersToContext,
-  calculateFitDimensions,
-  createFilterString,
-  drawGrid,
-} from './lib';
+import { calculateFitDimensions, createFilterString, drawGrid } from './lib';
 import { FilterKey, type Filters, type PointRecord } from './types';
 
 /**
@@ -246,23 +241,31 @@ export class CanvasEditor {
   }
 
   /**
-   * Основной метод отрисовки. Вызывает применение фильтров и отрисовку сетки.
+   * Приватный метод отрисовки на заданном контексте.
+   * Содержит общую логику отрисовки для render() и toDataURL().
+   * @param ctx - Контекст для отрисовки
+   * @param width - Ширина области отрисовки
+   * @param height - Высота области отрисовки
+   * @param includeGrid - Включать ли сетку в отрисовку
    */
-  public render() {
-    if (!this.img || !this.ctx) {
+  private draw(
+    ctx: CanvasRenderingContext2D,
+    width: number,
+    height: number,
+    includeGrid: boolean,
+  ) {
+    if (!this.img) {
       return;
     }
 
-    const { width, height } = this.canvas;
-
     // 1. Рисуем белую подложку (холст)
-    this.ctx.save();
-    this.ctx.clearRect(0, 0, width, height);
-    this.ctx.fillStyle = '#ffffff';
-    this.ctx.fillRect(0, 0, width, height);
+    ctx.save();
+    ctx.clearRect(0, 0, width, height);
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, width, height);
 
     // 2. Рисуем изображение с учетом трансформаций (зум и пан внутри кадра)
-    this.ctx.filter = createFilterString(this.filters);
+    ctx.filter = createFilterString(this.filters);
 
     // Вычисляем размеры отрисовки
     const drawWidth = width * this.zoom;
@@ -272,14 +275,26 @@ export class CanvasEditor {
     const x = (width - drawWidth) / 2 + this.offset.x;
     const y = (height - drawHeight) / 2 + this.offset.y;
 
-    this.ctx.drawImage(this.img, x, y, drawWidth, drawHeight);
-    this.ctx.filter = 'none';
-    this.ctx.restore();
+    ctx.drawImage(this.img, x, y, drawWidth, drawHeight);
+    ctx.filter = 'none';
+    ctx.restore();
 
     // 3. Сетка рисуется ПОВЕРХ всего, но она привязана к границам подложки (кадра)
-    if (this.isGridVisible) {
-      drawGrid(this.ctx, width, height);
+    if (includeGrid) {
+      drawGrid(ctx, width, height);
     }
+  }
+
+  /**
+   * Основной метод отрисовки. Вызывает применение фильтров и отрисовку сетки.
+   */
+  public render() {
+    if (!this.img || !this.ctx) {
+      return;
+    }
+
+    const { width, height } = this.canvas;
+    this.draw(this.ctx, width, height, this.isGridVisible);
   }
 
   /**
@@ -290,19 +305,21 @@ export class CanvasEditor {
   }
 
   /**
-   * Экспортирует текущее состояние в dataURL с сохранением оригинальных размеров изображения.
+   * Экспортирует текущий кадр (viewport) в dataURL.
+   * Сохраняет именно то, что видит пользователь: кадр с учетом зума, пана и фильтров.
    * @param type - MIME тип (image/jpeg, image/png)
    * @param quality - Качество сжатия (0..1)
    */
   public toDataURL(type = 'image/jpeg', quality = 1): string {
-    if (!this.img) {
+    if (!this.img || !this.ctx) {
       return '';
     }
 
-    const width = this.img.naturalWidth;
-    const height = this.img.naturalHeight;
+    // Используем размеры текущего кадра (viewport), а не оригинального изображения
+    const width = this.canvas.width;
+    const height = this.canvas.height;
 
-    // Используем временный холст для экспорта в оригинальном разрешении
+    // Создаем временный холст с размерами кадра
     const tempCanvas = document.createElement('canvas');
     tempCanvas.width = width;
     tempCanvas.height = height;
@@ -312,13 +329,8 @@ export class CanvasEditor {
       return '';
     }
 
-    applyFiltersToContext(
-      tempCtx,
-      this.img,
-      this.filters,
-      tempCanvas.width,
-      tempCanvas.height,
-    );
+    // Отрисовываем текущий кадр БЕЗ сетки (сетка - это только UI-направляющая)
+    this.draw(tempCtx, width, height, false);
 
     return tempCanvas.toDataURL(type, quality);
   }

--- a/src/features/download-image/__tests__/model.test.ts
+++ b/src/features/download-image/__tests__/model.test.ts
@@ -1,0 +1,200 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { allSettled, fork } from 'effector';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  $canvas,
+  imageQualityChanged,
+  imageUploadStarted,
+} from '~/entities/image';
+
+import { donwloadButtonClicked, downloadImageFx } from '../model';
+
+describe('Download Image Feature', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockEditor: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockLink: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEditor = {
+      toDataURL: vi.fn().mockReturnValue('data:image/jpeg;base64,dGVzdA=='),
+      getCanvas: vi.fn(),
+    };
+
+    mockLink = {
+      download: '',
+      href: '',
+      click: vi.fn(),
+      remove: vi.fn(),
+    };
+
+    // Mock document.createElement
+
+    // @ts-ignore
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).document.createElement = vi
+      .fn()
+      .mockImplementation((tag: string) => {
+        if (tag === 'a') {
+          return mockLink;
+        }
+        return document.createElement(tag);
+      });
+
+    // Mock URL methods
+
+    // @ts-ignore
+    global.URL.createObjectURL = vi.fn().mockReturnValue('blob:test');
+
+    // @ts-ignore
+    global.URL.revokeObjectURL = vi.fn();
+
+    // Mock window
+
+    // @ts-ignore
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).window = {
+      // @ts-ignore
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ...(global as any).window,
+      showSaveFilePicker: undefined,
+    };
+  });
+
+  it('should throw error if no image is loaded', async () => {
+    const scope = fork({
+      values: [[$canvas, mockEditor]],
+    });
+
+    // Проверяем, что эффект завершится с ошибкой при отсутствии изображения
+    const result = await allSettled(downloadImageFx, {
+      scope,
+      // @ts-expect-error
+      params: { image: null, quality: 100, editor: mockEditor },
+    });
+    expect(result.status).toBe('fail');
+    if (result.status === 'fail') {
+      expect(result.value.message).toBe('no image to download');
+    }
+  });
+
+  it('should use File System Access API when available', async () => {
+    const mockFileHandle = {
+      createWritable: vi.fn().mockResolvedValue({
+        write: vi.fn().mockResolvedValue(undefined),
+        close: vi.fn().mockResolvedValue(undefined),
+      }),
+    };
+
+    const mockShowSaveFilePicker = vi.fn().mockResolvedValue(mockFileHandle);
+    // @ts-ignore
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).window = {
+      // @ts-ignore
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ...(global as any).window,
+      showSaveFilePicker: mockShowSaveFilePicker,
+    };
+
+    const mockFile = new File(['test'], 'test.jpg', { type: 'image/jpeg' });
+    const scope = fork({
+      values: [[$canvas, mockEditor]],
+    });
+
+    await allSettled(imageUploadStarted, { scope, params: mockFile });
+    await allSettled(donwloadButtonClicked, { scope });
+
+    expect(mockShowSaveFilePicker).toHaveBeenCalledWith({
+      suggestedName: 'test.jpg',
+      types: [
+        {
+          description: 'Image files',
+          accept: {
+            'image/jpeg': ['.jpg'],
+          },
+        },
+      ],
+    });
+    expect(mockFileHandle.createWritable).toHaveBeenCalled();
+  });
+
+  it('should fallback to download link if File System API is not available', async () => {
+    // @ts-ignore
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).window = {
+      // @ts-ignore
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ...(global as any).window,
+      showSaveFilePicker: undefined,
+    };
+    // @ts-ignore
+    const mockFile = new File(['test'], 'test.jpg', { type: 'image/jpeg' });
+    const scope = fork({
+      values: [[$canvas, mockEditor]],
+    });
+
+    await allSettled(imageUploadStarted, { scope, params: mockFile });
+    await allSettled(donwloadButtonClicked, { scope });
+
+    expect(document.createElement).toHaveBeenCalledWith('a');
+    expect(mockLink.click).toHaveBeenCalled();
+    expect(mockLink.download).toBe('test.jpg');
+    // @ts-ignore
+    expect(global.URL.createObjectURL).toHaveBeenCalled();
+  });
+
+  it('should handle user cancellation gracefully', async () => {
+    const mockShowSaveFilePicker = vi.fn().mockRejectedValue({
+      name: 'AbortError',
+    });
+    // @ts-ignore
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).window = {
+      // @ts-ignore
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ...(global as any).window,
+      showSaveFilePicker: mockShowSaveFilePicker,
+    };
+
+    const mockFile = new File(['test'], 'test.jpg', { type: 'image/jpeg' });
+    const scope = fork({
+      values: [[$canvas, mockEditor]],
+    });
+
+    await allSettled(imageUploadStarted, { scope, params: mockFile });
+    await allSettled(donwloadButtonClicked, { scope });
+
+    // При отмене пользователем эффект должен завершиться успешно (возвращает false)
+    expect(mockShowSaveFilePicker).toHaveBeenCalled();
+    // Проверяем, что fallback на скачивание не был вызван
+    expect(document.createElement).not.toHaveBeenCalledWith('a');
+  });
+
+  it('should convert dataURL to Blob correctly', async () => {
+    const mockFile = new File(['test'], 'test.png', { type: 'image/png' });
+    const scope = fork({
+      values: [[$canvas, mockEditor]],
+    });
+
+    await allSettled(imageUploadStarted, { scope, params: mockFile });
+    await allSettled(imageQualityChanged, { scope, params: 80 });
+    await allSettled(donwloadButtonClicked, { scope });
+
+    // Проверяем, что toDataURL был вызван с правильными параметрами
+    expect(mockEditor.toDataURL).toHaveBeenCalledWith('image/png', 0.8);
+  });
+
+  it('should use correct file extension based on MIME type', async () => {
+    const mockFile = new File(['test'], 'test.webp', { type: 'image/webp' });
+    const scope = fork({
+      values: [[$canvas, mockEditor]],
+    });
+
+    await allSettled(imageUploadStarted, { scope, params: mockFile });
+    await allSettled(donwloadButtonClicked, { scope });
+
+    expect(mockLink.download).toBe('test.webp');
+  });
+});

--- a/src/features/download-image/model.ts
+++ b/src/features/download-image/model.ts
@@ -4,6 +4,36 @@ import { $canvas, $imageQuality, $imageRaw } from '~/entities/image';
 
 export const donwloadButtonClicked = createEvent();
 
+/**
+ * Конвертирует dataURL в Blob
+ */
+function dataURLToBlob(dataURL: string): Blob {
+  const arr = dataURL.split(',');
+  const mimeMatch = arr[0].match(/:(.*?);/);
+  const mime = mimeMatch ? mimeMatch[1] : 'image/jpeg';
+  const bstr = atob(arr[1]);
+  let n = bstr.length;
+  const u8arr = new Uint8Array(n);
+  while (n--) {
+    u8arr[n] = bstr.charCodeAt(n);
+  }
+  return new Blob([u8arr], { type: mime });
+}
+
+/**
+ * Получает расширение файла из MIME типа
+ */
+function getExtensionFromMime(mime: string): string {
+  const mimeMap: Record<string, string> = {
+    'image/jpeg': 'jpg',
+    'image/jpg': 'jpg',
+    'image/png': 'png',
+    'image/webp': 'webp',
+    'image/gif': 'gif',
+  };
+  return mimeMap[mime] || 'jpg';
+}
+
 export const downloadImageFx = attach({
   source: { image: $imageRaw, quality: $imageQuality, editor: $canvas },
   effect: async ({ image, quality, editor }) => {
@@ -16,16 +46,57 @@ export const downloadImageFx = attach({
       quality / 100,
     );
 
-    if (dataUrl) {
-      const link = document.createElement('a');
-      link.download = image.name || 'edited-image';
-      link.href = dataUrl;
-      link.click();
-      link.remove();
-      return true;
+    if (!dataUrl) {
+      throw new Error('cannot generate image data');
     }
 
-    throw new Error('cannot generate image data');
+    const blob = dataURLToBlob(dataUrl);
+    const mime = image.type || 'image/jpeg';
+    const extension = getExtensionFromMime(mime);
+    const defaultName = image.name
+      ? image.name.replace(/\.[^.]+$/, `.${extension}`)
+      : `edited-image.${extension}`;
+
+    // Пробуем использовать File System Access API (современные браузеры)
+    if ('showSaveFilePicker' in globalThis.window) {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const fileHandle = await (globalThis.window as any).showSaveFilePicker({
+          suggestedName: defaultName,
+          types: [
+            {
+              description: 'Image files',
+              accept: {
+                [mime]: [`.${extension}`],
+              },
+            },
+          ],
+        });
+
+        const writable = await fileHandle.createWritable();
+        await writable.write(blob);
+        await writable.close();
+        {
+          return true;
+        }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } catch (error: any) {
+        // Пользователь отменил диалог - это нормально, не бросаем ошибку
+        if (error.name === 'AbortError') {
+          return false;
+        }
+        // Если произошла другая ошибка, пробуем fallback на скачивание
+      }
+    }
+
+    // Fallback: скачивание через <a> элемент (для старых браузеров)
+    const link = document.createElement('a');
+    link.download = defaultName;
+    link.href = URL.createObjectURL(blob);
+    link.click();
+    link.remove();
+    URL.revokeObjectURL(link.href);
+    return true;
   },
 });
 


### PR DESCRIPTION
- Рефакторинг CanvasEditor: вынес логику отрисовки в приватный метод draw()
- Обновлен toDataURL() для сохранения текущего viewport вместо оригинала
- Реализован File System Access API (showSaveFilePicker) для выбора пути сохранения
- Добавлен fallback на скачивание через <a> для старых браузеров
- Добавлены тесты для экспорта кадра и процесса сохранения